### PR TITLE
Remove Trailing Slash From URL

### DIFF
--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonRecorder.java
@@ -6,6 +6,7 @@ import com.mesosphere.velocity.marathon.fields.MarathonLabel;
 import com.mesosphere.velocity.marathon.fields.MarathonUri;
 import com.mesosphere.velocity.marathon.interfaces.AppConfig;
 import com.mesosphere.velocity.marathon.interfaces.MarathonBuilder;
+import com.mesosphere.velocity.marathon.util.MarathonBuilderUtils;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
@@ -45,7 +46,7 @@ public class MarathonRecorder extends Recorder implements AppConfig {
 
     @DataBoundConstructor
     public MarathonRecorder(final String url) {
-        this.url = url;
+        this.url = MarathonBuilderUtils.rmSlashFromUrl(url);
 
         this.uris = new ArrayList<MarathonUri>(5);
         this.labels = new ArrayList<MarathonLabel>(5);

--- a/src/main/java/com/mesosphere/velocity/marathon/MarathonStep.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/MarathonStep.java
@@ -4,6 +4,7 @@ import com.mesosphere.velocity.marathon.fields.MarathonLabel;
 import com.mesosphere.velocity.marathon.fields.MarathonUri;
 import com.mesosphere.velocity.marathon.interfaces.AppConfig;
 import com.mesosphere.velocity.marathon.interfaces.MarathonBuilder;
+import com.mesosphere.velocity.marathon.util.MarathonBuilderUtils;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -31,7 +32,7 @@ public class MarathonStep extends AbstractStepImpl implements AppConfig {
 
     @DataBoundConstructor
     public MarathonStep(final String url) {
-        this.url = url;
+        this.url = MarathonBuilderUtils.rmSlashFromUrl(url);
         this.uris = new ArrayList<String>(5);
         this.labels = new HashMap<String, String>(5);
     }

--- a/src/main/java/com/mesosphere/velocity/marathon/util/MarathonBuilderUtils.java
+++ b/src/main/java/com/mesosphere/velocity/marathon/util/MarathonBuilderUtils.java
@@ -38,4 +38,14 @@ public class MarathonBuilderUtils {
      * Definition.
      */
     public static final String JSON_EMPTY_CONTAINER    = "{\"type\": \"DOCKER\"}";
+
+    /**
+     * Remove the trailing slash from url.
+     *
+     * @param url the URL
+     * @return URL with the trailing slash removed, if it exists.
+     */
+    public static String rmSlashFromUrl(final String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
 }

--- a/src/test/java/com/mesosphere/velocity/marathon/util/MarathonBuilderUtilsTest.java
+++ b/src/test/java/com/mesosphere/velocity/marathon/util/MarathonBuilderUtilsTest.java
@@ -1,0 +1,17 @@
+package com.mesosphere.velocity.marathon.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MarathonBuilderUtilsTest {
+
+    @Test
+    public void testRmTrailingSlash() throws Exception {
+        final String withSlash = "sometext/";
+        final String noSlash   = "sometext";
+
+        assertEquals(noSlash, MarathonBuilderUtils.rmSlashFromUrl(withSlash));
+        assertEquals(noSlash, MarathonBuilderUtils.rmSlashFromUrl(noSlash));
+    }
+}


### PR DESCRIPTION
A marathon instance URL ending in a slash is not handled properly when sending an application update. This commit removes a trailing slash if present.